### PR TITLE
docs: 增加内容

### DIFF
--- a/data/mao_trajectory_events.json
+++ b/data/mao_trajectory_events.json
@@ -1796,6 +1796,23 @@
       "verification": ""
     },
     {
+      "date": "1958-09",
+      "age": 75,
+      "movementType": "长途移动",
+      "event": "视察安徽",
+      "coordinates": {
+        "start": {
+          "province": "安徽省",
+          "city": "合肥市"
+        },
+        "end": {
+          "province": "安徽省",
+          "city": "马鞍山市"
+        }
+      },
+      "verification": "http://dangshi.people.com.cn/n/2013/1225/c85037-23945725.html"
+    },
+    {
       "date": "1959-07-02",
       "age": 65,
       "movementType": "长途移动",


### PR DESCRIPTION
## 新增历史事件

- **日期**: 1958-09
- **地点**: 安徽省
- **事件简述**: 考察安徽
- **重要性级别**: 🔴 一级事件
- **事件类型**: 长途移动 

**详细描述**:
对安徽的省会城市设置和建设，毛泽东至为关心。 1951年12月，皖南区党委和行署迁至合肥，与皖北区党委和行署合并办公，1952年1月，党中央批准成立中共安徽省委，省委、省政府办公地点设在合肥。关于省会地点，当时有一种意见认为，应该设在芜湖，芜湖靠近长江，交通便利。 1958年9月，毛泽东在安徽视察期间，亲笔给安徽省委第一书记曾希圣写信：“合肥不错，为皖之中，是否要搬芜湖呢？从长远考虑，似较适宜。”

1958年9月和1959年10月，毛泽东两次到马鞍山视察。重点视察马鞍山钢铁工业的发展情况。毛泽东冒雨参观了马鞍山钢铁公司的5号高炉（今9号高炉），炼钢车间及7号、8号高炉，烧结厂破碎车间，一钢厂白云石车间，三焦厂“红旗”2号土焦炉，还登上一座小土丘，眺望了未来的新厂区。

**史料依据 (最重要！)**:
http://dangshi.people.com.cn/n/2013/1225/c85037-23945725.html

**录入标准自查**:

- [x] 涉及明确的地理移动
- [x] 具有高度的历史重要性
- [x] 史料来源可供查证

